### PR TITLE
Route audio session id to server.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [1.19.0] - 2020-09-29
 ### Added
 - Add MeetingReadinessCheckerConfiguration to allow custom configuration for meeting readiness checker
+- Add audioSessionId to join frame to always drop when reconnecting
 
 ### Changed
 - Update Travis config to improve PR build speed

--- a/demos/browser/package-lock.json
+++ b/demos/browser/package-lock.json
@@ -274,6 +274,7 @@
       "requires": {
         "@types/dom-mediacapture-record": "^1.0.4",
         "detect-browser": "^5.1.0",
+        "long": "^4.0.0",
         "protobufjs": "~6.8.8",
         "resize-observer": "^1.0.0"
       },
@@ -1291,6 +1292,11 @@
             "shebang-command": "^2.0.0",
             "which": "^2.0.1"
           }
+        },
+        "crypto-js": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/crypto-js/-/crypto-js-4.0.0.tgz",
+          "integrity": "sha512-bzHZN8Pn+gS7DQA6n+iUmBfl0hO5DJq++QP3U6uTucDtk/0iGpXd/Gg7CGR0p8tJhofJyaKoWBuJI4eAO00BBg=="
         },
         "d": {
           "version": "1.0.1",
@@ -4998,9 +5004,9 @@
       }
     },
     "aws-sdk": {
-      "version": "2.763.0",
-      "resolved": "https://registry.npmjs.org/aws-sdk/-/aws-sdk-2.763.0.tgz",
-      "integrity": "sha512-uHb+yfsH21wR8ZInj/GQwxCmWJjrL3sOwqwZ2lf9hDxh1P0lsMKDjf0e+8ICgRBY4x28XNWXs3/O15EID6Rsqw==",
+      "version": "2.770.0",
+      "resolved": "https://registry.npmjs.org/aws-sdk/-/aws-sdk-2.770.0.tgz",
+      "integrity": "sha512-CUkyXwFxEJ32AxH2tjBFfG4grjFdyDjyBaltYzaLa0U2KvGgDIj28q8psdxhALTm3c9zPEoMYpRXiTyRNmkROQ==",
       "requires": {
         "buffer": "4.9.2",
         "events": "1.1.1",

--- a/demos/browser/package.json
+++ b/demos/browser/package.json
@@ -33,7 +33,7 @@
   },
   "dependencies": {
     "amazon-chime-sdk-js": "file:../..",
-    "aws-sdk": "^2.763.0",
+    "aws-sdk": "^2.770.0",
     "bootstrap": "^4.5.2",
     "compression": "^1.7.4",
     "jquery": "^3.5.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "amazon-chime-sdk-js",
-  "version": "1.19.3",
+  "version": "1.19.4",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "amazon-chime-sdk-js",
-  "version": "1.19.3",
+  "version": "1.19.4",
   "description": "Amazon Chime SDK for JavaScript",
   "main": "build/index.js",
   "types": "build/index.d.ts",
@@ -69,7 +69,8 @@
     "@types/dom-mediacapture-record": "^1.0.4",
     "detect-browser": "^5.1.0",
     "protobufjs": "~6.8.8",
-    "resize-observer": "^1.0.0"
+    "resize-observer": "^1.0.0",
+    "long": "^4.0.0"
   },
   "license": "Apache-2.0",
   "repository": {

--- a/protocol/SignalingProtocol.proto
+++ b/protocol/SignalingProtocol.proto
@@ -71,6 +71,7 @@ message SdkJoinFrame {
     optional uint32 max_num_of_videos = 2 [default=8];
     optional uint32 flags = 3;
     optional SdkClientDetails client_details = 4;
+    optional uint64 audio_session_id = 6;
 }
 
 message SdkJoinAckFrame {

--- a/src/signalingclient/DefaultSignalingClient.ts
+++ b/src/signalingclient/DefaultSignalingClient.ts
@@ -1,6 +1,9 @@
 // Copyright 2019-2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
+// import { randomBytes } from 'crypto';
+import * as Long from 'long';
+
 import DefaultBrowserBehavior from '../browserbehavior/DefaultBrowserBehavior';
 import Logger from '../logger/Logger';
 import SignalingClientObserver from '../signalingclientobserver/SignalingClientObserver';
@@ -40,12 +43,14 @@ export default class DefaultSignalingClient implements SignalingClient {
   private isClosing: boolean;
   private connectionRequestQueue: SignalingClientConnectionRequest[];
   private unloadHandler: () => void | null = null;
+  private audioSessionId: Long;
 
   constructor(private webSocket: WebSocketAdapter, private logger: Logger) {
     this.observerQueue = new Set<SignalingClientObserver>();
     this.connectionRequestQueue = [];
     this.resetConnection();
     this.logger.debug(() => 'signaling client init');
+    this.audioSessionId = this.generateNewAudioSessionId();
   }
 
   registerObserver(observer: SignalingClientObserver): void {
@@ -91,6 +96,7 @@ export default class DefaultSignalingClient implements SignalingClient {
       clientSource: Versioning.sdkName,
       chimeSdkVersion: Versioning.sdkVersion,
     });
+    joinFrame.audioSessionId = this.audioSessionId;
 
     const message = SdkSignalFrame.create();
     message.type = SdkSignalFrame.Type.JOIN;
@@ -377,5 +383,11 @@ export default class DefaultSignalingClient implements SignalingClient {
       GlobalAny['window']['addEventListener'] &&
       window.removeEventListener('unload', this.unloadHandler);
     this.unloadHandler = null;
+  }
+
+  private generateNewAudioSessionId(): Long {
+    const nums = new Uint32Array(2);
+    const randomNums = window.crypto.getRandomValues(nums);
+    return new Long(randomNums[0], randomNums[1], true);
   }
 }

--- a/src/signalingprotocol/SignalingProtocol.d.ts
+++ b/src/signalingprotocol/SignalingProtocol.d.ts
@@ -471,6 +471,9 @@ export interface ISdkJoinFrame {
 
     /** SdkJoinFrame clientDetails */
     clientDetails?: (ISdkClientDetails|null);
+
+    /** SdkJoinFrame audioSessionId */
+    audioSessionId?: (number|Long|null);
 }
 
 /** Represents a SdkJoinFrame. */
@@ -493,6 +496,9 @@ export class SdkJoinFrame implements ISdkJoinFrame {
 
     /** SdkJoinFrame clientDetails. */
     public clientDetails?: (ISdkClientDetails|null);
+
+    /** SdkJoinFrame audioSessionId. */
+    public audioSessionId: (number|Long);
 
     /**
      * Creates a new SdkJoinFrame instance using the specified properties.

--- a/src/signalingprotocol/SignalingProtocol.js
+++ b/src/signalingprotocol/SignalingProtocol.js
@@ -1402,6 +1402,7 @@ $root.SdkJoinFrame = (function() {
      * @property {number|null} [maxNumOfVideos] SdkJoinFrame maxNumOfVideos
      * @property {number|null} [flags] SdkJoinFrame flags
      * @property {ISdkClientDetails|null} [clientDetails] SdkJoinFrame clientDetails
+     * @property {number|Long|null} [audioSessionId] SdkJoinFrame audioSessionId
      */
 
     /**
@@ -1452,6 +1453,14 @@ $root.SdkJoinFrame = (function() {
     SdkJoinFrame.prototype.clientDetails = null;
 
     /**
+     * SdkJoinFrame audioSessionId.
+     * @member {number|Long} audioSessionId
+     * @memberof SdkJoinFrame
+     * @instance
+     */
+    SdkJoinFrame.prototype.audioSessionId = $util.Long ? $util.Long.fromBits(0,0,true) : 0;
+
+    /**
      * Creates a new SdkJoinFrame instance using the specified properties.
      * @function create
      * @memberof SdkJoinFrame
@@ -1483,6 +1492,8 @@ $root.SdkJoinFrame = (function() {
             writer.uint32(/* id 3, wireType 0 =*/24).uint32(message.flags);
         if (message.clientDetails != null && message.hasOwnProperty("clientDetails"))
             $root.SdkClientDetails.encode(message.clientDetails, writer.uint32(/* id 4, wireType 2 =*/34).fork()).ldelim();
+        if (message.audioSessionId != null && message.hasOwnProperty("audioSessionId"))
+            writer.uint32(/* id 6, wireType 0 =*/48).uint64(message.audioSessionId);
         return writer;
     };
 
@@ -1528,6 +1539,9 @@ $root.SdkJoinFrame = (function() {
                 break;
             case 4:
                 message.clientDetails = $root.SdkClientDetails.decode(reader, reader.uint32());
+                break;
+            case 6:
+                message.audioSessionId = reader.uint64();
                 break;
             default:
                 reader.skipType(tag & 7);
@@ -1578,6 +1592,9 @@ $root.SdkJoinFrame = (function() {
             if (error)
                 return "clientDetails." + error;
         }
+        if (message.audioSessionId != null && message.hasOwnProperty("audioSessionId"))
+            if (!$util.isInteger(message.audioSessionId) && !(message.audioSessionId && $util.isInteger(message.audioSessionId.low) && $util.isInteger(message.audioSessionId.high)))
+                return "audioSessionId: integer|Long expected";
         return null;
     };
 
@@ -1604,6 +1621,15 @@ $root.SdkJoinFrame = (function() {
                 throw TypeError(".SdkJoinFrame.clientDetails: object expected");
             message.clientDetails = $root.SdkClientDetails.fromObject(object.clientDetails);
         }
+        if (object.audioSessionId != null)
+            if ($util.Long)
+                (message.audioSessionId = $util.Long.fromValue(object.audioSessionId)).unsigned = true;
+            else if (typeof object.audioSessionId === "string")
+                message.audioSessionId = parseInt(object.audioSessionId, 10);
+            else if (typeof object.audioSessionId === "number")
+                message.audioSessionId = object.audioSessionId;
+            else if (typeof object.audioSessionId === "object")
+                message.audioSessionId = new $util.LongBits(object.audioSessionId.low >>> 0, object.audioSessionId.high >>> 0).toNumber(true);
         return message;
     };
 
@@ -1625,6 +1651,11 @@ $root.SdkJoinFrame = (function() {
             object.maxNumOfVideos = 8;
             object.flags = 0;
             object.clientDetails = null;
+            if ($util.Long) {
+                var long = new $util.Long(0, 0, true);
+                object.audioSessionId = options.longs === String ? long.toString() : options.longs === Number ? long.toNumber() : long;
+            } else
+                object.audioSessionId = options.longs === String ? "0" : 0;
         }
         if (message.protocolVersion != null && message.hasOwnProperty("protocolVersion"))
             object.protocolVersion = message.protocolVersion;
@@ -1634,6 +1665,11 @@ $root.SdkJoinFrame = (function() {
             object.flags = message.flags;
         if (message.clientDetails != null && message.hasOwnProperty("clientDetails"))
             object.clientDetails = $root.SdkClientDetails.toObject(message.clientDetails, options);
+        if (message.audioSessionId != null && message.hasOwnProperty("audioSessionId"))
+            if (typeof message.audioSessionId === "number")
+                object.audioSessionId = options.longs === String ? String(message.audioSessionId) : message.audioSessionId;
+            else
+                object.audioSessionId = options.longs === String ? $util.Long.prototype.toString.call(message.audioSessionId) : options.longs === Number ? new $util.LongBits(message.audioSessionId.low >>> 0, message.audioSessionId.high >>> 0).toNumber(true) : message.audioSessionId;
         return object;
     };
 

--- a/src/versioning/Versioning.ts
+++ b/src/versioning/Versioning.ts
@@ -18,7 +18,7 @@ export default class Versioning {
    * Return string representation of SDK version
    */
   static get sdkVersion(): string {
-    return '1.19.3';
+    return '1.19.4';
   }
 
   /**

--- a/test/dommock/DOMMockBuilder.ts
+++ b/test/dommock/DOMMockBuilder.ts
@@ -1084,6 +1084,12 @@ export default class DOMMockBuilder {
 
       disconnect(): void {}
     };
+
+    GlobalAny.crypto = {
+      getRandomValues(_data: Uint32Array): Uint32Array {
+        return new Uint32Array([Math.trunc(Math.random() * (2 ** 32)), Math.trunc(Math.random() * (2 ** 32))]);
+      },
+    };
   }
 
   cleanup(): void {

--- a/test/pingpong/DefaultPingPong.test.ts
+++ b/test/pingpong/DefaultPingPong.test.ts
@@ -19,13 +19,26 @@ import {
   SdkSignalFrame,
 } from '../../src/signalingprotocol/SignalingProtocol.js';
 import DefaultWebSocketAdapter from '../../src/websocketadapter/DefaultWebSocketAdapter';
+import DOMMockBuilder from '../dommock/DOMMockBuilder';
 
 describe('DefaultPingPong', () => {
   let expect: Chai.ExpectStatic;
   const defaultIntervalMs = 10000;
   const logger = new NoOpLogger(LogLevel.DEBUG);
+  let domMockBuilder: DOMMockBuilder | null = null;
   before(() => {
     expect = chai.expect;
+  });
+
+  beforeEach(() => {
+    domMockBuilder = new DOMMockBuilder();
+  });
+
+  afterEach(() => {
+    if (domMockBuilder) {
+      domMockBuilder.cleanup();
+      domMockBuilder = null;
+    }
   });
 
   describe('construction', () => {


### PR DESCRIPTION
Fixes bug when AttendeeLeft event was sometimes seen in place of AttendeeDropped when reconnecting.

Issue #:
#727
Description of changes:
Routes random session id to server.
Testing

Have you successfully run npm run build:release locally?
Yes
How did you test these changes?
Started a meeting
Checked session id performed as expected on the backend
Ensured correct events were emitted
Do you add, modify, or delete public API definitions? If yes, has that been reviewed and approved?
No
Do you change the wire protocol, e.g. the request method? If yes, has that been reviewed and approved?
Yes. Yes.
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.